### PR TITLE
Adjust ExUnit commands to localize focused, file tests using --only argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "email": "daniel@strunk.me",
     "url": "https://danielstrunk.me"
   },
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "vscode": "^1.69.0"
   },

--- a/src/lib/runners/elixir/exunit.ts
+++ b/src/lib/runners/elixir/exunit.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { AbstractRunner, LocalConfig } from "../../runner";
 import { testType } from "../../../extension";
 
@@ -13,11 +14,11 @@ export class ExUnit extends AbstractRunner {
   }
 
   focusedTest() {
-    return `${this.command} ${this.fileName}:${this.lineNumber}`;
+    return `${this.command} --only ${this.fileName}:${this.lineNumber}`;
   }
 
   testFile() {
-    return `${this.command} ${this.fileName}`;
+    return `${this.command} --only ${this.fileName}`;
   }
 
   testSuite() {
@@ -43,7 +44,14 @@ export class ExUnit extends AbstractRunner {
   }
 
   get fileName(): string {
-    return this.document.fileName;
+    const fullPath = this.document.fileName;
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(this.document.uri);
+
+    if (workspaceFolder) {
+        return path.relative(workspaceFolder.uri.fsPath, fullPath);
+    }
+
+    return fullPath;
   }
 
   get testName(): string {


### PR DESCRIPTION
- Adjust ExUnit commands to localize focused, file tests using `--only` argument
- Adjust `get fileName` path to return path relative to the project directory; this is helpful when working on containerized applications