### PR TITLE
Add root directory to allow running ExUnit commands in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Here are the currently available configuration options (settings should be added
     "agnostic-test.javascript.jest.command": null,
     "agnostic-test.javascript.mocha.command": null,
     "agnostic-test.javascript.cypress.command": null,
-    "agnostic-test.elixir.exunit.command": null
+    "agnostic-test.elixir.exunit.command": null,
+    "agnostic-test.elixir.exunit.docker.rootDirectory": null
 }
 ```
 
@@ -93,7 +94,10 @@ Create a `.testrc.json` file in the root of your directory with the following co
 
     "elixir": {
         "exunit": {
-            "command": null
+            "command": null,
+            "docker": {
+                "rootDirectory": null,
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "email": "daniel@strunk.me",
     "url": "https://danielstrunk.me"
   },
-  "version": "0.5.0",
+  "version": "0.6.0",
   "engines": {
     "vscode": "^1.69.0"
   },
@@ -97,6 +97,14 @@
           ],
           "default": null,
           "description": "A custom Elixir ExUnit command. Default command is `mix test`."
+        },
+        "agnostic-test.elixir.exunit.docker.rootDirectory": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "If the Elixir project is part of a Docker Compose project, and the command is running in a Docker container, provide the root directory of your Elixir application here."
         }
       }
     }

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -41,6 +41,9 @@ export interface LocalConfig {
     elixir?: {
         exunit?: {
             command?: string;
+            docker?: {
+                rootDirectory?: string;
+            }
         }
     }
 }

--- a/src/lib/runners/javascript/cypress.ts
+++ b/src/lib/runners/javascript/cypress.ts
@@ -25,16 +25,10 @@ export class Cypress extends AbstractRunner {
   }
 
   get command() {
-    let command;
-    if (this.localConfig) {
-      command = this.localConfig?.javascript?.cypress?.command;
+    const command = this.localConfig?.javascript?.cypress?.command
+      ?? vscode.workspace.getConfiguration('agnostic-test').get('javascript.cypress.command')
+      ?? null;
 
-      if (command) {
-        return command;
-      }
-    }
-
-    command = vscode.workspace.getConfiguration('agnostic-test').get('javascript.cypress.command');
     if (command) {
         return command;
     }

--- a/src/lib/runners/javascript/jest.ts
+++ b/src/lib/runners/javascript/jest.ts
@@ -25,18 +25,10 @@ export class Jest extends AbstractRunner {
   }
 
   get command() {
-    let command;
-    if (this.localConfig) {
-      command = this.localConfig?.javascript?.jest?.command;
+    const command = this.localConfig?.javascript?.jest?.command
+      ?? vscode.workspace.getConfiguration("agnostic-test").get("javascript.jest.command")
+      ?? null;
 
-      if (command) {
-        return command;
-      }
-    }
-
-    command = vscode.workspace
-      .getConfiguration("agnostic-test")
-      .get("javascript.jest.command");
     if (command) {
       return command;
     }

--- a/src/lib/runners/javascript/mocha.ts
+++ b/src/lib/runners/javascript/mocha.ts
@@ -25,16 +25,10 @@ export class Mocha extends AbstractRunner {
   }
 
   get command() {
-    let command;
-    if (this.localConfig) {
-      command = this.localConfig?.javascript?.mocha?.command;
+    const command = this.localConfig?.javascript?.mocha?.command
+      ?? vscode.workspace.getConfiguration('agnostic-test').get('javascript.mocha.command')
+      ?? null;
 
-      if (command) {
-        return command;
-      }
-    }
-
-    command = vscode.workspace.getConfiguration('agnostic-test').get('javascript.mocha.command');
     if (command) {
         return command;
     }

--- a/src/lib/runners/php/pest.ts
+++ b/src/lib/runners/php/pest.ts
@@ -25,16 +25,10 @@ export class Pest extends AbstractRunner {
   }
 
   get command() {
-    let command;
-    if (this.localConfig) {
-      command = this.localConfig?.php?.pest?.command;
+    const command = this.localConfig?.php?.pest?.command
+      ?? vscode.workspace.getConfiguration('agnostic-test').get('php.pest.command')
+      ?? null;
 
-      if (command) {
-        return command;
-      }
-    }
-
-    command = vscode.workspace.getConfiguration('agnostic-test').get('php.pest.command');
     if (command) {
         return command;
     }

--- a/src/lib/runners/php/phpunit.ts
+++ b/src/lib/runners/php/phpunit.ts
@@ -25,16 +25,10 @@ export class PHPUnit extends AbstractRunner {
   }
 
   get command() {
-    let command;
-    if (this.localConfig) {
-      command = this.localConfig?.php?.phpunit?.command;
+    const command = this.localConfig?.php?.phpunit?.command
+      ?? vscode.workspace.getConfiguration('agnostic-test').get('php.phpunit.command')
+      ?? null;
 
-      if (command) {
-        return command;
-      }
-    }
-
-    command = vscode.workspace.getConfiguration('agnostic-test').get('php.phpunit.command');
     if (command) {
         return command;
     }


### PR DESCRIPTION
Add a `rootDirectory` config option to ExUnit to ensure paths are correct when running ExUnit commands in a Docker context. Path can be an absolute local path up to the directory, or a directory relative to the workspace.

Fixes #9.