### PR TITLE
Restore focus to the window the command was run in

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
---ignore-engines true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "agnostic-test" extension will be documented in this file.
 
+## [1.0.0]
+
+Officially calling it ... 1.0.0 :confetti:
+
+### Enhancement
+
+- After running tests, return focus to the previous window so users can continue editing code.
+
 ## [0.8.1]
 ### Fixed
 - Issue where custom commands were not running as expected.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "email": "daniel@strunk.me",
     "url": "https://danielstrunk.me"
   },
-  "version": "0.8.1",
+  "version": "1.0.0",
   "engines": {
     "vscode": "^1.69.0"
   },
@@ -166,10 +166,10 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "yarn esbuild-base --minify",
+    "vscode:prepublish": "npm run esbuild-base --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/main.js --external:vscode --format=cjs --platform=node",
-    "esbuild": "yarn esbuild-base --sourcemap",
-    "esbuild-watch": "yarn esbuild-base --sourcemap --watch",
+    "esbuild": "npm run esbuild-base --sourcemap",
+    "esbuild-watch": "npm run esbuild-base --sourcemap --watch",
     "test-compile": "tsc -p ./",
     "test": "jest",
     "eslint": "eslint ."

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -55,29 +55,44 @@ export abstract class AbstractRunner implements IRunner {
         }
     }
 
-    run(): void {
+    async run(): Promise<void> {
         const terminal = this.getOrCreateTerminal();
+        const editor = vscode.window.activeTextEditor;
+        const position = editor?.selection.active;
 
         switch (this.testStrategy) {
         case "focused":
-            // vscode.commands.executeCommand('workbench.action.terminal.clear');
+            vscode.commands.executeCommand('workbench.action.terminal.clear');
             terminal.show();
-            return terminal.sendText(this.focusedTest());
+            terminal.sendText(this.focusedTest());
+            break;
 
         case "file":
             vscode.commands.executeCommand('workbench.action.terminal.clear');
             terminal.show();
-            return terminal.sendText(this.testFile());
+            terminal.sendText(this.testFile());
+            break;
 
         case "suite":
             vscode.commands.executeCommand('workbench.action.terminal.clear');
             terminal.show();
-            return terminal.sendText(this.testSuite());
+            terminal.sendText(this.testSuite());
+            break;
 
         default:
             vscode.commands.executeCommand('workbench.action.terminal.clear');
             terminal.show();
-            return terminal.sendText(this.testSuite());
+            terminal.sendText(this.testSuite());
+            break;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        if (editor && position) {
+            await vscode.window.showTextDocument(editor.document, {
+                selection: new vscode.Selection(position, position),
+                preserveFocus: false,
+            });
         }
     }
 


### PR DESCRIPTION
After running a test, return focus to the window the command was run from.

1.0.0 release! :confetti:

Closes #5.